### PR TITLE
Multiple queries with LIMIT cause an NPE due to retained state.

### DIFF
--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/input/HiveCassandraStandardColumnInputFormat.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/input/HiveCassandraStandardColumnInputFormat.java
@@ -42,7 +42,6 @@ public class HiveCassandraStandardColumnInputFormat extends
   static final Log LOG = LogFactory.getLog(HiveCassandraStandardColumnInputFormat.class);
 
   private boolean isTransposed;
-  private Iterator<Map.Entry<ByteBuffer, IColumn>> currentRecordIterator;
   private Map.Entry<ByteBuffer, IColumn> currentEntry;
   private Iterator<IColumn> subcolumnIterator;
 
@@ -109,6 +108,7 @@ public class HiveCassandraStandardColumnInputFormat extends
       throw new IOException(ie);
     }
     return new RecordReader<Text, HiveCassandraStandardRowResult>() {
+      private Iterator<Map.Entry<ByteBuffer, IColumn>> currentRecordIterator;
 
       @Override
       public void close() throws IOException {

--- a/cassandra-handler/src/test/queries/transposed_table.q
+++ b/cassandra-handler/src/test/queries/transposed_table.q
@@ -45,6 +45,9 @@ select row_key, sub_column_name, value from superLog;
 
 select row_key, value from superLog where column_name = 'divide' and sub_column_name = '3';
 
+select * from accessLog limit 1;
+select * from accessLog limit 1;
+
 DROP TABLE accessLog;
 DROP TABLE superLog;
 

--- a/cassandra-handler/src/test/results/cassandra_queries.q.out
+++ b/cassandra-handler/src/test/results/cassandra_queries.q.out
@@ -24,11 +24,11 @@ value	string	from deserializer
 PREHOOK: query: select * from cassandra_hive_table
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-47_066_8546316163674745608/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-03_020_2968819949976156258/-mr-10000
 POSTHOOK: query: select * from cassandra_hive_table
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-47_066_8546316163674745608/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-03_020_2968819949976156258/-mr-10000
 PREHOOK: query: EXPLAIN FROM src INSERT OVERWRITE TABLE cassandra_hive_table SELECT * WHERE (key%7)=0 ORDER BY key
 PREHOOK: type: QUERY
 POSTHOOK: query: EXPLAIN FROM src INSERT OVERWRITE TABLE cassandra_hive_table SELECT * WHERE (key%7)=0 ORDER BY key
@@ -118,11 +118,11 @@ STAGE PLANS:
 PREHOOK: query: select * from cassandra_hive_table
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-52_900_2485203720466139106/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-08_266_3951555005863806079/-mr-10000
 POSTHOOK: query: select * from cassandra_hive_table
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-52_900_2485203720466139106/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-08_266_3951555005863806079/-mr-10000
 0	val_0
 105	val_105
 119	val_119
@@ -219,11 +219,11 @@ STAGE PLANS:
 PREHOOK: query: select * from cassandra_hive_table ORDER BY key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-53_160_6110572608081171996/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-08_391_4184676871495932189/-mr-10000
 POSTHOOK: query: select * from cassandra_hive_table ORDER BY key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-53_160_6110572608081171996/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-08_391_4184676871495932189/-mr-10000
 0	val_0
 28	val_28
 35	val_35
@@ -316,11 +316,11 @@ STAGE PLANS:
 PREHOOK: query: select key from cassandra_hive_table ORDER BY key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-57_329_3314066313864959990/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-13_586_5775837859040034112/-mr-10000
 POSTHOOK: query: select key from cassandra_hive_table ORDER BY key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-58-57_329_3314066313864959990/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-13_586_5775837859040034112/-mr-10000
 0
 28
 35
@@ -413,11 +413,11 @@ STAGE PLANS:
 PREHOOK: query: select value from cassandra_hive_table ORDER BY VALUE
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-01_105_559123746736146402/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-17_174_3202199844009165309/-mr-10000
 POSTHOOK: query: select value from cassandra_hive_table ORDER BY VALUE
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-01_105_559123746736146402/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-17_174_3202199844009165309/-mr-10000
 val_0
 val_105
 val_119
@@ -537,7 +537,7 @@ STAGE PLANS:
   Stage: Stage-2
     Map Reduce
       Alias -> Map Operator Tree:
-        file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-04_979_6108421819776889598/-mr-10002 
+        file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-21_080_7715127821323755215/-mr-10002 
             Reduce Output Operator
               key expressions:
                     expr: _col0
@@ -568,11 +568,11 @@ STAGE PLANS:
 PREHOOK: query: select a.key,a.value,b.value from cassandra_hive_table a JOIN cassandra_hive_table b on a.key=b.key ORDER BY a.key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-05_235_4041589656110432028/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-21_221_6734143376601986504/-mr-10000
 POSTHOOK: query: select a.key,a.value,b.value from cassandra_hive_table a JOIN cassandra_hive_table b on a.key=b.key ORDER BY a.key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-05_235_4041589656110432028/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-21_221_6734143376601986504/-mr-10000
 0	val_0	val_0
 28	val_28	val_28
 35	val_35	val_35
@@ -713,7 +713,7 @@ STAGE PLANS:
   Stage: Stage-2
     Map Reduce
       Alias -> Map Operator Tree:
-        file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-15_971_4894794724062144114/-mr-10002 
+        file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-29_285_7422267437223311664/-mr-10002 
             Reduce Output Operator
               key expressions:
                     expr: _col0
@@ -752,7 +752,7 @@ ORDER BY key, value LIMIT 20
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
 PREHOOK: Input: default@src
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-16_197_4866293203583116826/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-29_462_5096882938955052467/-mr-10000
 POSTHOOK: query: SELECT Y.*
 FROM
 (SELECT cassandra_hive_table.* FROM cassandra_hive_table) x
@@ -763,7 +763,7 @@ ORDER BY key, value LIMIT 20
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
 POSTHOOK: Input: default@src
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-16_197_4866293203583116826/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-29_462_5096882938955052467/-mr-10000
 0	val_0
 0	val_0
 0	val_0
@@ -918,7 +918,7 @@ STAGE PLANS:
   Stage: Stage-2
     Map Reduce
       Alias -> Map Operator Tree:
-        file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-28_722_126436102988179757/-mr-10002 
+        file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-38_279_3705970580538625549/-mr-10002 
             Reduce Output Operator
               key expressions:
                     expr: _col0
@@ -956,7 +956,7 @@ ORDER BY key,value
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
 PREHOOK: Input: default@cassandra_hive_table2
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-28_836_1888781140851443781/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-38_404_6312636904624155410/-mr-10000
 POSTHOOK: query: SELECT Y.*
 FROM
 (SELECT cassandra_hive_table.* FROM cassandra_hive_table WHERE cassandra_hive_table.key > 100) x
@@ -967,7 +967,7 @@ ORDER BY key,value
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
 POSTHOOK: Input: default@cassandra_hive_table2
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-28_836_1888781140851443781/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-38_404_6312636904624155410/-mr-10000
 PREHOOK: query: DROP TABLE empty_cassandra_table
 PREHOOK: type: DROPTABLE
 POSTHOOK: query: DROP TABLE empty_cassandra_table
@@ -985,12 +985,8 @@ POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: default@empty_cassandra_table
 PREHOOK: query: DROP TABLE empty_normal_table
 PREHOOK: type: DROPTABLE
-PREHOOK: Input: default@empty_normal_table
-PREHOOK: Output: default@empty_normal_table
 POSTHOOK: query: DROP TABLE empty_normal_table
 POSTHOOK: type: DROPTABLE
-POSTHOOK: Input: default@empty_normal_table
-POSTHOOK: Output: default@empty_normal_table
 PREHOOK: query: CREATE TABLE empty_normal_table(key int, value string)
 PREHOOK: type: CREATETABLE
 POSTHOOK: query: CREATE TABLE empty_normal_table(key int, value string)
@@ -1000,48 +996,48 @@ PREHOOK: query: select * from (select count(1) as c from empty_normal_table unio
 PREHOOK: type: QUERY
 PREHOOK: Input: default@empty_cassandra_table
 PREHOOK: Input: default@empty_normal_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-42_028_7287941689035417012/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-46_743_7738245251834740251/-mr-10000
 POSTHOOK: query: select * from (select count(1) as c from empty_normal_table union all select count(1) as c from empty_cassandra_table) x order by c
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@empty_cassandra_table
 POSTHOOK: Input: default@empty_normal_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-42_028_7287941689035417012/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-46_743_7738245251834740251/-mr-10000
 0
 0
 PREHOOK: query: select * from (select count(1) c from empty_normal_table union all select count(1) as c from empty_cassandra_table) x order by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@empty_cassandra_table
 PREHOOK: Input: default@empty_normal_table
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-56_573_979433057339033645/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-59_593_2269629585501718360/-mr-10000
 POSTHOOK: query: select * from (select count(1) c from empty_normal_table union all select count(1) as c from empty_cassandra_table) x order by c
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@empty_cassandra_table
 POSTHOOK: Input: default@empty_normal_table
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_16-59-56_573_979433057339033645/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-46-59_593_2269629585501718360/-mr-10000
 0
 0
 PREHOOK: query: select * from (select count(1) c from src union all select count(1) as c from empty_cassandra_table) x order by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@empty_cassandra_table
 PREHOOK: Input: default@src
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-00-11_443_6246629736254990671/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-10_225_6184730264315025762/-mr-10000
 POSTHOOK: query: select * from (select count(1) c from src union all select count(1) as c from empty_cassandra_table) x order by c
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@empty_cassandra_table
 POSTHOOK: Input: default@src
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-00-11_443_6246629736254990671/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-10_225_6184730264315025762/-mr-10000
 0
 500
 PREHOOK: query: select * from (select count(1) c from src union all select count(1) as c from cassandra_hive_table) x order by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table
 PREHOOK: Input: default@src
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-00-28_688_8312502060230740869/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-21_168_2848232534818414590/-mr-10000
 POSTHOOK: query: select * from (select count(1) c from src union all select count(1) as c from cassandra_hive_table) x order by c
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table
 POSTHOOK: Input: default@src
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-00-28_688_8312502060230740869/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-21_168_2848232534818414590/-mr-10000
 43
 500
 PREHOOK: query: DROP TABLE cassandra_hive_table3
@@ -1243,20 +1239,20 @@ POSTHOOK: Output: default@cassandra_hive_table3
 PREHOOK: query: select count(1) from cassandra_hive_table3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table3
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-00-56_779_4596434453521846397/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-42_772_4813012057644054817/-mr-10000
 POSTHOOK: query: select count(1) from cassandra_hive_table3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table3
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-00-56_779_4596434453521846397/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-42_772_4813012057644054817/-mr-10000
 43
 PREHOOK: query: select * from cassandra_hive_table3 order by key, value limit 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table3
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-00_726_4882698178425708463/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-47_035_6039794702841987002/-mr-10000
 POSTHOOK: query: select * from cassandra_hive_table3 order by key, value limit 5
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table3
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-00_726_4882698178425708463/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-47_035_6039794702841987002/-mr-10000
 0	val_0	3
 28	val_28	1
 35	val_35	3
@@ -1265,11 +1261,11 @@ POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizh
 PREHOOK: query: select key, count from cassandra_hive_table3 order by key, count desc limit 5
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table3
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-05_890_758265918508116346/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-51_480_352162668466175161/-mr-10000
 POSTHOOK: query: select key, count from cassandra_hive_table3 order by key, count desc limit 5
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table3
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-05_890_758265918508116346/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-51_480_352162668466175161/-mr-10000
 0	3
 28	1
 35	3
@@ -1303,11 +1299,11 @@ POSTHOOK: Output: default@cassandra_hive_table4
 PREHOOK: query: SELECT * FROM cassandra_hive_table4 ORDER BY key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table4
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-16_813_7625784293001874597/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-59_201_5889032681037673030/-mr-10000
 POSTHOOK: query: SELECT * FROM cassandra_hive_table4 ORDER BY key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table4
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-16_813_7625784293001874597/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-47-59_201_5889032681037673030/-mr-10000
 98	val_98	99	100
 100	val_100	101	102
 PREHOOK: query: DROP TABLE cassandra_hive_table5
@@ -1338,11 +1334,11 @@ POSTHOOK: Output: default@cassandra_hive_table5
 PREHOOK: query: SELECT * FROM cassandra_hive_table5 ORDER BY key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table5
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-25_487_6925087920615075701/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-48-06_945_2539867540783539644/-mr-10000
 POSTHOOK: query: SELECT * FROM cassandra_hive_table5 ORDER BY key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table5
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-25_487_6925087920615075701/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-48-06_945_2539867540783539644/-mr-10000
 98	{"val_98":"98"}
 100	{"val_100":"100"}
 PREHOOK: query: --Test batch mutation size
@@ -1375,11 +1371,11 @@ POSTHOOK: Output: default@cassandra_hive_table6
 PREHOOK: query: SELECT * FROM cassandra_hive_table6 ORDER BY key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@cassandra_hive_table6
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-35_973_6441159046847949942/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-48-14_988_3824533902174945236/-mr-10000
 POSTHOOK: query: SELECT * FROM cassandra_hive_table6 ORDER BY key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@cassandra_hive_table6
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-01-35_973_6441159046847949942/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_02-48-14_988_3824533902174945236/-mr-10000
 0	val_0	1	2	3	val_0
 42	val_42	43	44	45	val_42
 84	val_84	85	86	87	val_84

--- a/cassandra-handler/src/test/results/transposed_table.q.out
+++ b/cassandra-handler/src/test/results/transposed_table.q.out
@@ -18,11 +18,11 @@ POSTHOOK: Output: default@accessLog
 PREHOOK: query: select * from accessLog
 PREHOOK: type: QUERY
 PREHOOK: Input: default@accesslog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-12_800_4021658363540237256/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-17_432_4707153886360149325/-mr-10000
 POSTHOOK: query: select * from accessLog
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@accesslog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-12_800_4021658363540237256/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-17_432_4707153886360149325/-mr-10000
 PREHOOK: query: INSERT OVERWRITE TABLE accessLog
 select key, 'divide7', value  from src where (key%7)=0
 PREHOOK: type: QUERY
@@ -36,11 +36,11 @@ POSTHOOK: Output: default@accesslog
 PREHOOK: query: select row_key, column_name, value from accessLog
 PREHOOK: type: QUERY
 PREHOOK: Input: default@accesslog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-17_105_6611791197122205293/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-22_019_630264497183045473/-mr-10000
 POSTHOOK: query: select row_key, column_name, value from accessLog
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@accesslog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-17_105_6611791197122205293/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-22_019_630264497183045473/-mr-10000
 0	divide7	val_0
 105	divide7	val_105
 119	divide7	val_119
@@ -97,11 +97,11 @@ POSTHOOK: Output: default@accesslog
 PREHOOK: query: select row_key from accessLog
 PREHOOK: type: QUERY
 PREHOOK: Input: default@accesslog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-24_123_175759811298163883/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-30_990_178493848308681423/-mr-10000
 POSTHOOK: query: select row_key from accessLog
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@accesslog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-24_123_175759811298163883/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-30_990_178493848308681423/-mr-10000
 0
 0
 105
@@ -179,11 +179,11 @@ POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizh
 PREHOOK: query: select * from accessLog where column_name != 'divide9'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@accesslog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-28_170_8622998756035269978/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-35_338_3816008941884923956/-mr-10000
 POSTHOOK: query: select * from accessLog where column_name != 'divide9'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@accesslog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-28_170_8622998756035269978/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-35_338_3816008941884923956/-mr-10000
 0	divide7	val_0
 105	divide7	val_105
 119	divide7	val_119
@@ -230,11 +230,11 @@ POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizh
 PREHOOK: query: select row_key, count(*) from accessLog where row_key > 70 group by row_key
 PREHOOK: type: QUERY
 PREHOOK: Input: default@accesslog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-32_851_8662349843217796802/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-39_929_8126565956859467025/-mr-10000
 POSTHOOK: query: select row_key, count(*) from accessLog where row_key > 70 group by row_key
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@accesslog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-32_851_8662349843217796802/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-39_929_8126565956859467025/-mr-10000
 105	1
 119	1
 126	2
@@ -316,11 +316,11 @@ POSTHOOK: Output: default@superLog
 PREHOOK: query: select * from superLog
 PREHOOK: type: QUERY
 PREHOOK: Input: default@superlog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-39_448_5374271894869754952/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-45_519_8906867808175603517/-mr-10000
 POSTHOOK: query: select * from superLog
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@superlog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-39_448_5374271894869754952/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-45_519_8906867808175603517/-mr-10000
 PREHOOK: query: INSERT OVERWRITE TABLE superLog
 select key, 'divide', '5', value  from src where (key%5)=0
 PREHOOK: type: QUERY
@@ -334,11 +334,11 @@ POSTHOOK: Output: default@superlog
 PREHOOK: query: select * from superLog
 PREHOOK: type: QUERY
 PREHOOK: Input: default@superlog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-46_203_8517016729424708687/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-51_484_6199091505608884722/-mr-10000
 POSTHOOK: query: select * from superLog
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@superlog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-46_203_8517016729424708687/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-51_484_6199091505608884722/-mr-10000
 0	divide	5	val_0
 10	divide	5	val_10
 100	divide	5	val_100
@@ -410,11 +410,11 @@ POSTHOOK: Output: default@superlog
 PREHOOK: query: select row_key, sub_column_name, value from superLog
 PREHOOK: type: QUERY
 PREHOOK: Input: default@superlog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-53_126_6543748693195910529/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-58_867_5588144740086665487/-mr-10000
 POSTHOOK: query: select row_key, sub_column_name, value from superLog
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@superlog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-53_126_6543748693195910529/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-38-58_867_5588144740086665487/-mr-10000
 0	3	val_0
 10	5	val_10
 100	5	val_100
@@ -558,11 +558,11 @@ POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizh
 PREHOOK: query: select row_key, value from superLog where column_name = 'divide' and sub_column_name = '3'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@superlog
-PREHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-59_154_5538934266031746077/-mr-10000
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-39-03_709_4288118115051074902/-mr-10000
 POSTHOOK: query: select row_key, value from superLog where column_name = 'divide' and sub_column_name = '3'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@superlog
-POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizhang/hive_2011-06-13_17-43-59_154_5538934266031746077/-mr-10000
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-39-03_709_4288118115051074902/-mr-10000
 0	val_0
 105	val_105
 111	val_111
@@ -664,6 +664,24 @@ POSTHOOK: Output: file:/var/folders/b-/b-vBB2wVHpaVQzxVjeViaE+++TI/-Tmp-/yeweizh
 9	val_9
 90	val_90
 96	val_96
+PREHOOK: query: select * from accessLog limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@accesslog
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-39-08_690_1829116516767204906/-mr-10000
+POSTHOOK: query: select * from accessLog limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@accesslog
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-39-08_690_1829116516767204906/-mr-10000
+0	divide7	val_0
+PREHOOK: query: select * from accessLog limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@accesslog
+PREHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-39-08_746_4956529330014868408/-mr-10000
+POSTHOOK: query: select * from accessLog limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@accesslog
+POSTHOOK: Output: file:/var/folders/hn/vg_2g82d2jqbj5ws1k7rdgs80000gn/T/aaron/hive_2011-07-31_03-39-08_746_4956529330014868408/-mr-10000
+0	divide7	val_0
 PREHOOK: query: DROP TABLE accessLog
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@accesslog


### PR DESCRIPTION
See amorton/hive#1

Changed the HiveCassandraStandardColumnInputFormat and added tests to transposed_table.q . Commit includes updates to the test output because they were already in the repo. 

I think the problem was only with transposed tables.
