### PR TITLE
SlicePredicate/SliceRange support as Hive Table Properties

### DIFF
--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/CassandraStorageHandler.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/CassandraStorageHandler.java
@@ -89,10 +89,28 @@ public class CassandraStorageHandler
       tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SPLIT_SIZE,
           Integer.toString(StandardColumnSerDe.DEFAULT_SPLIT_SIZE)));
 
-
     jobProperties.put(StandardColumnSerDe.CASSANDRA_BATCH_MUTATION_SIZE,
-        tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_BATCH_MUTATION_SIZE,
-            Integer.toString(StandardColumnSerDe.DEFAULT_BATCH_MUTATION_SIZE)));
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_BATCH_MUTATION_SIZE,
+          Integer.toString(StandardColumnSerDe.DEFAULT_BATCH_MUTATION_SIZE)));
+
+    // SlicePredicate
+    jobProperties.put(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_START,
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_START, ""));
+
+    jobProperties.put(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_FINISH,
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_FINISH, ""));
+
+    jobProperties.put(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_COMPARATOR,
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_COMPARATOR, ""));
+
+    jobProperties.put(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED,
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED, "false"));
+
+    jobProperties.put(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_COUNT,
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_COUNT, "false"));
+
+    jobProperties.put(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_COLUMN_NAMES,
+      tableProperties.getProperty(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_COLUMN_NAMES, ""));
   }
 
   @Override

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/input/HiveCassandraStandardColumnInputFormat.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/input/HiveCassandraStandardColumnInputFormat.java
@@ -10,6 +10,8 @@ import java.util.SortedMap;
 
 import org.apache.cassandra.db.IColumn;
 import org.apache.cassandra.db.SuperColumn;
+import org.apache.cassandra.db.marshal.AbstractType;
+import org.apache.cassandra.db.marshal.BytesType;
 import org.apache.cassandra.hadoop.ColumnFamilyInputFormat;
 import org.apache.cassandra.hadoop.ColumnFamilySplit;
 import org.apache.cassandra.hadoop.ConfigHelper;
@@ -74,11 +76,25 @@ public class HiveCassandraStandardColumnInputFormat extends
     SlicePredicate predicate = new SlicePredicate();
 
     if (isTransposed || readColIDs.size() == columns.size() || readColIDs.size() == 0) {
-      //We are reading all columns
       SliceRange range = new SliceRange();
-      range.setStart(new byte[0]);
-      range.setFinish(new byte[0]);
-      range.setReversed(false);
+      AbstractType comparator = null;
+      String comparatorType = jobConf.get(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_COMPARATOR);
+      if (!comparatorType.equals("")) {
+        try {
+          comparator = (AbstractType)Class.forName(comparatorType).getDeclaredField("instance").get(null);
+        } catch (ClassNotFoundException ex) {
+          comparator = BytesType.instance;
+        } catch (IllegalAccessException ex) {
+          comparator = BytesType.instance;
+        } catch (NoSuchFieldException ex) {
+          comparator = BytesType.instance;
+        }
+      } else {
+        comparator = BytesType.instance;
+      }
+      range.setStart(comparator.fromString(jobConf.get(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_START)));
+      range.setFinish(comparator.fromString(jobConf.get(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_FINISH)));
+      range.setReversed(jobConf.get(StandardColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED).equals("true"));
       range.setCount(cassandraSplit.getSlicePredicateSize());
       predicate.setSlice_range(range);
     } else {

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/AbstractColumnSerDe.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/AbstractColumnSerDe.java
@@ -34,6 +34,12 @@ public abstract class AbstractColumnSerDe implements SerDe {
 
   public static final String CASSANDRA_CF_NAME = "cassandra.cf.name"; // column family
   public static final String CASSANDRA_RANGE_BATCH_SIZE = "cassandra.range.size";
+  public static final String CASSANDRA_SLICE_PREDICATE_COLUMN_NAMES = "cassandra.slice.predicate.column_names";
+  public static final String CASSANDRA_SLICE_PREDICATE_RANGE_START = "cassandra.slice.predicate.range.start";
+  public static final String CASSANDRA_SLICE_PREDICATE_RANGE_FINISH = "cassandra.slice.predicate.range.finish";
+  public static final String CASSANDRA_SLICE_PREDICATE_RANGE_COMPARATOR = "cassandra.slice.predicate.range.comparator";
+  public static final String CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED = "cassandra.slice.predicate.range.reversed";
+  public static final String CASSANDRA_SLICE_PREDICATE_RANGE_COUNT = "cassandra.slice.predicate.range.count";
   public static final String CASSANDRA_SLICE_PREDICATE_SIZE = "cassandra.slice.predicate.size";
   public static final String CASSANDRA_SPLIT_SIZE = "cassandra.input.split.size";
   public static final String CASSANDRA_HOST = "cassandra.host"; // initialHost


### PR DESCRIPTION
Allows to do something like this:

```
CREATE EXTERNAL TABLE rangedb.idx(key string, foreign_value int, foreign_key string)
STORED BY 'org.apache.hadoop.hive.cassandra.CassandraStorageHandler'
WITH SERDEPROPERTIES ( "cassandra.cf.name" = "rowtest2", "cassandra.columns.mapping" = ":key,:column,:value")
TBLPROPERTIES (
    "cassandra.ks.name" = "rangetest",
    "cassandra.slice.predicate.range.start" = "50",
    "cassandra.slice.predicate.range.finish" = "800",
    "cassandra.slice.predicate.range.reversed" = "false",
    "cassandra.slice.predicate.range.comparator" = "org.apache.cassandra.db.marshal.IntegerType" );
```

This way the table is already narrowed to a desired range. Useful when doing indices in wide rows:

```
SELECT MyTable.* FROM MyTable LEFT SEMI JOIN MyTmpIdx ON (MyTable.key = idx.foreign_key);
```
