### PR TITLE
adding ttl property to column family mapping

### DIFF
--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/CassandraStorageHandler.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/CassandraStorageHandler.java
@@ -186,6 +186,18 @@ public class CassandraStorageHandler
       jobProperties.put(AbstractColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED,
           configuration.get(AbstractColumnSerDe.CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED));
     }
+	
+	if (configuration.get(AbstractColumnSerDe.CASSANDRA_TTL) == null)
+	{
+		jobProperties.put(AbstractColumnSerDe.CASSANDRA_TTL,
+		  tableProperties.getProperty(AbstractColumnSerDe.CASSANDRA_TTL,
+            Integer.toString(AbstractColumnSerDe.DEFAULT_CASSANDRA_TTL)));
+	}
+	else
+	{
+		jobProperties.put(AbstractColumnSerDe.CASSANDRA_TTL,
+		  configuration.get(AbstractColumnSerDe.CASSANDRA_TTL));
+	}
   }
 
   @Override

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/output/CassandraAbstractPut.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/output/CassandraAbstractPut.java
@@ -75,4 +75,16 @@ public abstract class CassandraAbstractPut implements Put {
       throw new IOException(e);
     }
   }
+  
+ /**
+  * Parse batch mutation size from job configuration. If none is defined, return the default value 500.
+  *
+  * @param jc job configuration
+  * @return batch mutation size
+  */
+ protected int getTtl(JobConf jc) {
+   return jc.getInt(
+       AbstractColumnSerDe.CASSANDRA_TTL,
+       AbstractColumnSerDe.DEFAULT_CASSANDRA_TTL);
+ } 
 }

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/output/CassandraPut.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/output/CassandraPut.java
@@ -15,6 +15,7 @@ import org.apache.cassandra.thrift.ConsistencyLevel;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.hadoop.hive.cassandra.CassandraProxyClient;
+import org.apache.hadoop.hive.cassandra.serde.AbstractColumnSerDe;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.JobConf;
 
@@ -100,13 +101,20 @@ public class CassandraPut extends CassandraAbstractPut implements Writable {
     Map<String, List<Mutation>> maps = new HashMap<String, List<Mutation>>();
 
     int count = 0;
+    int ttl = getTtl(jc);
+	
     // TODO check for counter
     for (CassandraColumn col : columns) {
       Column cassCol = new Column();
       cassCol.setValue(col.getValue());
       cassCol.setTimestamp(col.getTimeStamp());
       cassCol.setName(col.getColumn());
-
+	  
+	  if (ttl != AbstractColumnSerDe.DEFAULT_CASSANDRA_TTL)
+	  {
+        cassCol.setTtl(getTtl(jc));
+	  }
+	  
       ColumnOrSuperColumn thisCol = new ColumnOrSuperColumn();
       thisCol.setColumn(cassCol);
 

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/AbstractColumnSerDe.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/AbstractColumnSerDe.java
@@ -52,6 +52,7 @@ public abstract class AbstractColumnSerDe implements SerDe {
   public static final String CASSANDRA_SLICE_PREDICATE_RANGE_REVERSED = "cassandra.slice.predicate.range.reversed";
   public static final String CASSANDRA_SLICE_PREDICATE_RANGE_COUNT = "cassandra.slice.predicate.range.count";
   public static final String CASSANDRA_ENABLE_WIDEROW_ITERATOR = "cassandra.enable.widerow.iterator";
+  public static final String CASSANDRA_TTL = "cassandra.output.ttl"; //column family ttl
 
   public static final String CASSANDRA_SPECIAL_COLUMN_KEY = "row_key";
   public static final String CASSANDRA_SPECIAL_COLUMN_COL = "column_name";
@@ -73,7 +74,7 @@ public abstract class AbstractColumnSerDe implements SerDe {
   public static final String DEFAULT_CASSANDRA_PORT = "9160";
   public static final String DEFAULT_CONSISTENCY_LEVEL = "ONE";
   public static final int DEFAULT_BATCH_MUTATION_SIZE = 500;
-
+  public static final int DEFAULT_CASSANDRA_TTL = -1;
 
   /* names of columns from SerdeParameters */
   protected List<String> cassandraColumnNames;

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/RegularTableMapping.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/RegularTableMapping.java
@@ -81,7 +81,7 @@ public class RegularTableMapping extends TableMapping {
             System.arraycopy(serializeStream.getData(), 0, value, 0, serializeStream.getCount());
 
             CassandraColumn cc = new CassandraColumn();
-            cc.setTimeStamp(System.currentTimeMillis());
+            cc.setTimeStamp(System.currentTimeMillis() * 1000);
             cc.setColumnFamily(cassandraColumnFamily);
             cc.setColumn(columnQualifier);
             cc.setValue(value);
@@ -91,7 +91,7 @@ public class RegularTableMapping extends TableMapping {
         }
       } else {
         CassandraColumn cc = new CassandraColumn();
-        cc.setTimeStamp(System.currentTimeMillis());
+        cc.setTimeStamp(System.currentTimeMillis() * 1000);
         cc.setColumnFamily(cassandraColumnFamily);
         cc.setColumn(cassandraColumn.getBytes());
         byte[] key = serializeToBytes(foi, doi, f, useJsonSerialize(i, declaredFields));

--- a/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/TransposedMapping.java
+++ b/cassandra-handler/src/java/org/apache/hadoop/hive/cassandra/serde/TransposedMapping.java
@@ -42,7 +42,7 @@ public class TransposedMapping extends TableMapping {
       //A regular column family mapping
       CassandraPut put = new CassandraPut(ByteBuffer.wrap(keyBytes));
       CassandraColumn cc = new CassandraColumn();
-      cc.setTimeStamp(System.currentTimeMillis());
+      cc.setTimeStamp(System.currentTimeMillis() * 1000);
       cc.setColumnFamily(cassandraColumnFamily);
       cc.setColumn(serializeToBytes(columnName, fields, list, declaredFields));
       cc.setValue(serializeToBytes(columnValue, fields, list, declaredFields));
@@ -60,7 +60,7 @@ public class TransposedMapping extends TableMapping {
           useJsonSerialize(columnName, declaredFields));
       CassandraPut column = new CassandraPut(ByteBuffer.wrap(colName));
       CassandraColumn cc = new CassandraColumn();
-      cc.setTimeStamp(System.currentTimeMillis());
+      cc.setTimeStamp(System.currentTimeMillis() * 1000);
       cc.setColumnFamily(cassandraColumnFamily);
       cc.setColumn(serializeToBytes(subColumnName, fields, list, declaredFields));
       cc.setValue(serializeToBytes(columnValue, fields, list, declaredFields));


### PR DESCRIPTION
This adds an option to set a default ttl to new/updated columns from hive queries.

This option is relevant even after CASSANDRA-3974 because you can set different ttl for diferent columns and also use a low ttl to emulate delete in hive.
